### PR TITLE
Add glow effect and dynamic brightness for bubbles

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,11 +244,12 @@
             
             // Создаем пузыри с кластерным распределением
             for (let i = 0; i < bubbleCount; i++) {
-                const radius = Math.random() * 0.8 + 0.5; // Немного меньше размер для большего количества
-                const geometry = new THREE.SphereGeometry(radius, 16, 8); // Меньше полигонов для производительности
-                
+                const baseRadius = Math.random() * 0.8 + 0.5; // Немного меньше размер для большего количества
+                const geometry = new THREE.SphereGeometry(baseRadius, 16, 8); // Меньше полигонов для производительности
+
                 // Цвета пузырей
                 const hue = (i / bubbleCount) * 0.8 + Math.random() * 0.2;
+                const baseBrightness = 0.2;
                 const material = new THREE.MeshPhysicalMaterial({
                     color: new THREE.Color().setHSL(hue, 0.7, 0.5),
                     metalness: 0.1,
@@ -256,12 +257,33 @@
                     transparent: true,
                     opacity: 0.7,
                     emissive: new THREE.Color().setHSL(hue, 0.7, 0.2),
-                    emissiveIntensity: 0.2,
+                    emissiveIntensity: baseBrightness,
                     side: THREE.DoubleSide
                 });
-                
+
                 const bubble = new THREE.Mesh(geometry, material);
-                
+
+                const glowMaterial = new THREE.SpriteMaterial({
+                    color: new THREE.Color().setHSL(hue, 0.7, 0.6),
+                    transparent: true,
+                    opacity: 0.35,
+                    blending: THREE.AdditiveBlending,
+                    depthWrite: false,
+                    depthTest: false
+                });
+                const glowSprite = new THREE.Sprite(glowMaterial);
+                const baseGlowScale = baseRadius * 4;
+                glowSprite.scale.set(baseGlowScale, baseGlowScale, 1);
+                bubble.add(glowSprite);
+
+                const sizeCoefficient = 0.3 + Math.random() * 1.4;
+                const brightnessCoefficient = 0.3 + Math.random() * 1.4;
+                const baseGlowOpacity = glowMaterial.opacity;
+
+                bubble.scale.setScalar(sizeCoefficient);
+                bubble.material.emissiveIntensity = baseBrightness * brightnessCoefficient;
+                glowMaterial.opacity = THREE.MathUtils.clamp(baseGlowOpacity * brightnessCoefficient, 0, 1);
+
                 // Создаем кластерное распределение для более реалистичного графа
                 const clusterIndex = Math.floor(Math.random() * 8); // 8 кластеров
                 const clusterAngle = (clusterIndex / 8) * Math.PI * 2;
@@ -276,7 +298,7 @@
                 
                 bubble.castShadow = true;
                 bubble.receiveShadow = true;
-                
+
                 // Сохраняем параметры для анимации
                 bubble.userData = {
                     id: i,
@@ -284,9 +306,16 @@
                     rotationSpeed: (Math.random() - 0.5) * 0.002,
                     originalPosition: bubble.position.clone(),
                     phase: Math.random() * Math.PI * 2,
-                    connections: []
+                    connections: [],
+                    baseRadius: baseRadius,
+                    baseBrightness: baseBrightness,
+                    sizeCoefficient: sizeCoefficient,
+                    brightnessCoefficient: brightnessCoefficient,
+                    glow: glowSprite,
+                    baseGlowScale: baseGlowScale,
+                    baseGlowOpacity: baseGlowOpacity
                 };
-                
+
                 scene.add(bubble);
                 bubbles.push(bubble);
             }
@@ -527,21 +556,41 @@
             // Анимация пузырей
             bubbles.forEach((bubble, index) => {
                 const userData = bubble.userData;
-                
+
                 // Плавное покачивание
                 bubble.position.x = userData.originalPosition.x + Math.sin(time * userData.floatSpeed + userData.phase) * 0.5;
                 bubble.position.y = userData.originalPosition.y + Math.sin(time * userData.floatSpeed * 1.3 + userData.phase) * 1;
                 bubble.position.z = userData.originalPosition.z + Math.cos(time * userData.floatSpeed * 0.7 + userData.phase) * 0.5;
-                
+
                 // Вращение
                 bubble.rotation.x += userData.rotationSpeed;
                 bubble.rotation.y += userData.rotationSpeed * 0.7;
-                
+
                 // Пульсация узлов с многими связями
                 const connectionCount = userData.connections.length;
+                let scalePulsation = 1;
                 if (connectionCount > 5) {
-                    const pulsation = 1 + Math.sin(time * 3 + index) * 0.1 * Math.min(connectionCount / 10, 1);
-                    bubble.scale.setScalar(pulsation);
+                    scalePulsation += Math.sin(time * 3 + index) * 0.1 * Math.min(connectionCount / 10, 1);
+                }
+                bubble.scale.setScalar(userData.sizeCoefficient * scalePulsation);
+
+                const brightnessPulseStrength = 0.5 + Math.min(connectionCount / 10, 1) * 0.5;
+                const brightnessPulsation = 1 + Math.sin(time * 2 + userData.phase) * 0.2 * brightnessPulseStrength;
+                bubble.material.emissiveIntensity = THREE.MathUtils.clamp(
+                    userData.baseBrightness * userData.brightnessCoefficient * brightnessPulsation,
+                    0,
+                    5
+                );
+
+                if (userData.glow) {
+                    const glowPulsation = 1 + Math.sin(time * 2.3 + userData.phase) * 0.15 * Math.min(connectionCount / 10, 1);
+                    const glowScale = userData.baseGlowScale * userData.sizeCoefficient * glowPulsation;
+                    userData.glow.scale.set(glowScale, glowScale, 1);
+                    userData.glow.material.opacity = THREE.MathUtils.clamp(
+                        userData.baseGlowOpacity * userData.brightnessCoefficient * brightnessPulsation,
+                        0,
+                        1
+                    );
                 }
             });
             


### PR DESCRIPTION
## Summary
- store base radius and brightness data with each bubble and attach a sprite-based glow effect
- randomize size and brightness coefficients per bubble and apply them to sphere scale and emissive/glow intensity
- refresh the animation loop to pulse emissive intensity and glow scale using the stored coefficients

## Testing
- not run (visual change)


------
https://chatgpt.com/codex/tasks/task_e_68d130cf7808832699fb8917a3f98d55