### PR TITLE
Add force visualization glow for bubbles

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,6 +313,21 @@
                 glowSprite.scale.set(baseGlowScale, baseGlowScale, 1);
                 bubble.add(glowSprite);
 
+                const forceGlowMaterial = new THREE.SpriteMaterial({
+                    map: bubbleGlowTexture,
+                    color: new THREE.Color().setHSL(hue, 0.85, 0.75),
+                    transparent: true,
+                    opacity: 0,
+                    blending: THREE.AdditiveBlending,
+                    depthWrite: false,
+                    depthTest: false
+                });
+                const forceGlowSprite = new THREE.Sprite(forceGlowMaterial);
+                const forceGlowBaseScale = baseGlowScale * 0.55;
+                forceGlowSprite.scale.set(forceGlowBaseScale, forceGlowBaseScale, 1);
+                forceGlowSprite.visible = false;
+                scene.add(forceGlowSprite);
+
                 const sizeCoefficient = 0.3 + Math.random() * 1.4;
                 const brightnessCoefficient = 0.3 + Math.random() * 1.4;
                 const baseGlowOpacity = glowMaterial.opacity;
@@ -355,8 +370,16 @@
                     densityAccumulator: new THREE.Vector3(),
                     pendingForce: new THREE.Vector3(),
                     neighborIndices: [],
-                    localDensity: 0
+                    localDensity: 0,
+                    forceGlow: forceGlowSprite,
+                    forceGlowBaseScale,
+                    forceGlowOffset: new THREE.Vector3(),
+                    forceGlowIntensity: 0,
+                    forceGlowBaseOpacity: 0,
+                    forceGlowTargetScale: forceGlowBaseScale
                 };
+
+                forceGlowSprite.position.copy(bubble.position);
 
                 scene.add(bubble);
                 bubbles.push(bubble);
@@ -688,6 +711,49 @@
                         pendingForce.copy(accumulator.multiplyScalar(strength));
                     }
                 }
+
+                const forceGlow = userData.forceGlow;
+                if (forceGlow) {
+                    const forceMagnitude = pendingForce.length();
+                    const normalizedStrength = Math.min(
+                        forceMagnitude / localDensityConfig.forceStrength,
+                        1
+                    );
+
+                    userData.forceGlowIntensity = normalizedStrength;
+                    userData.forceGlowBaseOpacity = normalizedStrength * 0.75;
+
+                    const offset = userData.forceGlowOffset;
+                    if (forceMagnitude > 0.0001) {
+                        offset.copy(pendingForce).normalize();
+                        const offsetDistance = THREE.MathUtils.lerp(
+                            userData.baseRadius * userData.sizeCoefficient * 2,
+                            localDensityConfig.neighborRadius * 0.4,
+                            normalizedStrength
+                        );
+                        offset.multiplyScalar(offsetDistance);
+                    } else {
+                        offset.set(0, 0, 0);
+                    }
+
+                    const baseScale = userData.forceGlowBaseScale;
+                    userData.forceGlowTargetScale = baseScale * (0.6 + normalizedStrength * 0.8);
+
+                    forceGlow.visible = normalizedStrength > 0.02;
+                    if (!forceGlow.visible) {
+                        forceGlow.material.opacity = 0;
+                    } else {
+                        forceGlow.material.opacity = THREE.MathUtils.clamp(
+                            userData.forceGlowBaseOpacity,
+                            0,
+                            1
+                        );
+                    }
+
+                    forceGlow.position.copy(basePosition).add(offset);
+                    const appliedScale = userData.forceGlowTargetScale;
+                    forceGlow.scale.set(appliedScale, appliedScale, 1);
+                }
             }
 
             for (let i = 0; i < bubbles.length; i++) {
@@ -739,6 +805,27 @@
                         0,
                         1
                     );
+                }
+
+                if (userData.forceGlow) {
+                    const forceGlow = userData.forceGlow;
+                    const intensity = userData.forceGlowIntensity || 0;
+                    const baseOpacity = userData.forceGlowBaseOpacity || 0;
+                    const isVisible = intensity > 0.02;
+                    forceGlow.visible = isVisible;
+
+                    if (isVisible) {
+                        const pulse = 0.85 + Math.sin(time * 3.5 + userData.phase) * 0.15 * (0.5 + intensity * 0.5);
+                        forceGlow.material.opacity = THREE.MathUtils.clamp(baseOpacity * pulse, 0, 1);
+
+                        const pulseScale = 0.9 + Math.sin(time * 4.1 + userData.phase * 1.3) * 0.1 * intensity;
+                        const targetScale = userData.forceGlowTargetScale * pulseScale;
+                        forceGlow.scale.set(targetScale, targetScale, 1);
+
+                        forceGlow.position.copy(basePosition).add(userData.forceGlowOffset);
+                    } else {
+                        forceGlow.material.opacity = 0;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- add a dedicated sprite-based glow for each bubble to visualize force direction and strength
- update the physics loop to position, scale, and fade the force glow according to pending force vectors
- synchronize the glow during rendering with subtle pulsing to match existing bubble effects

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d14ba16c00832693aae40ec0751c31