### PR TITLE
Add multidimensional graph dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,7 +584,7 @@
                 const bubbleColor = new THREE.Color().setHSL(hue, saturation, lightness);
                 const emissiveColor = new THREE.Color().setHSL(hue, Math.min(1, saturation * 0.85), Math.min(1, lightness + 0.15));
                 const glowColor = new THREE.Color().setHSL(hue, Math.min(1, saturation * 0.9), Math.min(1, lightness + 0.2));
-                const forceGlowColor = new THREE.Color().setHSL(hue, Math.min(1, saturation * 0.95), Math.min(1, lightness + 0.35));
+                const forceGlowColor = new THREE.Color().setHSL(hue, 0.85, 0.75);
 
                 const material = new THREE.MeshPhysicalMaterial({
                     color: bubbleColor,
@@ -629,8 +629,8 @@
                 forceGlowSprite.visible = false;
                 scene.add(forceGlowSprite);
 
-                const sizeCoefficient = 0.45 + Math.random() * 1.2;
-                const brightnessCoefficient = 0.6 + Math.random() * 0.9;
+                const sizeCoefficient = 0.3 + Math.random() * 1.4;
+                const brightnessCoefficient = 0.3 + Math.random() * 1.4;
                 const baseGlowOpacity = glowMaterial.opacity;
 
                 bubble.scale.setScalar(sizeCoefficient);

--- a/index.html
+++ b/index.html
@@ -126,6 +126,7 @@
         <div id="nodeCount" style="font-size: 12px;">Узлов: 0</div>
         <div id="connectionCount" style="font-size: 12px;">Связей: 0</div>
         <div id="avgConnections" style="font-size: 12px;">Среднее связей: 0</div>
+        <div id="dimensionStats" style="font-size: 12px; margin-top: 8px; opacity: 0.8; line-height: 1.4;"></div>
     </div>
     
     <div id="crosshair" style="display: none;"></div>
@@ -137,6 +138,38 @@
         let connections = [];
         let connectionLines = [];
         let bubbleGlowTexture;
+        const dimensions = [];
+        const dimensionConfigs = [
+            {
+                name: 'Исследование рынка',
+                color: 0x4a90e2,
+                size: new THREE.Vector3(260, 180, 260),
+                center: new THREE.Vector3(-260, 0, -180)
+            },
+            {
+                name: 'Ценность продукта',
+                color: 0xff6ec7,
+                size: new THREE.Vector3(260, 180, 260),
+                center: new THREE.Vector3(260, 0, -180)
+            },
+            {
+                name: 'Пользовательский опыт',
+                color: 0x7ed321,
+                size: new THREE.Vector3(260, 180, 260),
+                center: new THREE.Vector3(-260, 0, 220)
+            },
+            {
+                name: 'Операционные процессы',
+                color: 0xffb347,
+                size: new THREE.Vector3(260, 180, 260),
+                center: new THREE.Vector3(260, 0, 220)
+            }
+        ];
+        const tempVector = new THREE.Vector3();
+        const tempVector2 = new THREE.Vector3();
+        const tempMin = new THREE.Vector3();
+        const tempMax = new THREE.Vector3();
+        const tempHSL = { h: 0, s: 0, l: 0 };
         let moveForward = false, moveBackward = false;
         let moveLeft = false, moveRight = false;
         let moveUp = false, moveDown = false;
@@ -171,6 +204,7 @@
         const info = document.getElementById('info');
         const stats = document.getElementById('stats');
         const crosshair = document.getElementById('crosshair');
+        const dimensionStatsElement = document.getElementById('dimensionStats');
         
         startButton.addEventListener('click', () => {
             startScreen.style.display = 'none';
@@ -227,7 +261,10 @@
             const pointLight3 = new THREE.PointLight(0xffff00, 0.2, 300);
             pointLight3.position.set(0, 100, 0);
             scene.add(pointLight3);
-            
+
+            // Многомерные пространства
+            createDimensions();
+
             // Создание пузырей и связей
             createBubblesAndConnections();
             
@@ -252,10 +289,231 @@
             renderer.domElement.addEventListener('contextmenu', (e) => e.preventDefault());
         }
         
+        function createDimensions() {
+            if (dimensions.length > 0) {
+                dimensions.forEach(dimension => {
+                    if (dimension.group) {
+                        scene.remove(dimension.group);
+                    }
+                });
+                dimensions.length = 0;
+            }
+
+            dimensionConfigs.forEach((config, index) => {
+                const group = new THREE.Group();
+                group.position.copy(config.center);
+
+                const fillGeometry = new THREE.BoxGeometry(config.size.x, config.size.y, config.size.z);
+                const fillMaterial = new THREE.MeshBasicMaterial({
+                    color: config.color,
+                    transparent: true,
+                    opacity: 0.05,
+                    blending: THREE.AdditiveBlending,
+                    depthWrite: false,
+                    depthTest: false,
+                    side: THREE.DoubleSide
+                });
+                const fill = new THREE.Mesh(fillGeometry, fillMaterial);
+                fill.renderOrder = -2;
+                group.add(fill);
+
+                const outlineGeometry = new THREE.EdgesGeometry(fillGeometry);
+                const outlineMaterial = new THREE.LineBasicMaterial({
+                    color: config.color,
+                    transparent: true,
+                    opacity: 0.4,
+                    depthTest: false
+                });
+                const outline = new THREE.LineSegments(outlineGeometry, outlineMaterial);
+                outline.renderOrder = -1;
+                group.add(outline);
+
+                const floorGeometry = new THREE.PlaneGeometry(config.size.x * 0.96, config.size.z * 0.96, 1, 1);
+                const floorMaterial = new THREE.MeshBasicMaterial({
+                    color: config.color,
+                    transparent: true,
+                    opacity: 0.08,
+                    blending: THREE.AdditiveBlending,
+                    depthWrite: false,
+                    side: THREE.DoubleSide,
+                    depthTest: false
+                });
+                const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+                floor.rotation.x = -Math.PI / 2;
+                floor.position.y = -config.size.y / 2 + 2;
+                floor.renderOrder = -2;
+                group.add(floor);
+
+                const label = createDimensionLabelSprite(config.name, config.color);
+                label.position.set(0, config.size.y * 0.6, 0);
+                group.add(label);
+
+                const halfSize = config.size.clone().multiplyScalar(0.5);
+                const boundsMin = config.center.clone().sub(halfSize);
+                const boundsMax = config.center.clone().add(halfSize);
+
+                const dimension = {
+                    index,
+                    name: config.name,
+                    color: new THREE.Color(config.color),
+                    size: config.size.clone(),
+                    center: config.center.clone(),
+                    boundsMin,
+                    boundsMax,
+                    group,
+                    fill,
+                    outline,
+                    floor,
+                    label,
+                    labelBaseScale: { x: label.scale.x, y: label.scale.y },
+                    bubbleIndices: [],
+                    clusterCenters: [],
+                    pulseOffset: Math.random() * Math.PI * 2
+                };
+
+                const clusterCount = 5;
+                for (let c = 0; c < clusterCount; c++) {
+                    dimension.clusterCenters.push(samplePointInsideDimension(dimension, new THREE.Vector3(), 0.35));
+                }
+
+                dimensions.push(dimension);
+                scene.add(group);
+            });
+        }
+
+        function createDimensionLabelSprite(text, colorHex) {
+            const canvas = document.createElement('canvas');
+            const size = 256;
+            canvas.width = canvas.height = size;
+            const context = canvas.getContext('2d');
+            context.clearRect(0, 0, size, size);
+
+            const color = new THREE.Color(colorHex);
+            const strokeStyle = color.getStyle();
+
+            const padding = 32;
+            const radius = 48;
+
+            context.fillStyle = 'rgba(10, 10, 25, 0.75)';
+            context.strokeStyle = strokeStyle;
+            context.lineWidth = 6;
+            context.beginPath();
+            context.moveTo(padding + radius, padding);
+            context.lineTo(size - padding - radius, padding);
+            context.quadraticCurveTo(size - padding, padding, size - padding, padding + radius);
+            context.lineTo(size - padding, size - padding - radius);
+            context.quadraticCurveTo(size - padding, size - padding, size - padding - radius, size - padding);
+            context.lineTo(padding + radius, size - padding);
+            context.quadraticCurveTo(padding, size - padding, padding, size - padding - radius);
+            context.lineTo(padding, padding + radius);
+            context.quadraticCurveTo(padding, padding, padding + radius, padding);
+            context.closePath();
+            context.fill();
+            context.stroke();
+
+            context.font = 'bold 44px "Arial"';
+            context.fillStyle = 'rgba(255, 255, 255, 0.92)';
+            context.textAlign = 'center';
+            context.textBaseline = 'middle';
+
+            const words = text.split(' ');
+            const lines = [];
+            let currentLine = '';
+            words.forEach(word => {
+                const testLine = currentLine ? `${currentLine} ${word}` : word;
+                const metrics = context.measureText(testLine);
+                if (metrics.width > size - padding * 3 && currentLine) {
+                    lines.push(currentLine);
+                    currentLine = word;
+                } else {
+                    currentLine = testLine;
+                }
+            });
+            if (currentLine) {
+                lines.push(currentLine);
+            }
+
+            const lineHeight = 50;
+            const startY = size / 2 - ((lines.length - 1) * lineHeight) / 2;
+            lines.forEach((line, index) => {
+                context.fillText(line, size / 2, startY + index * lineHeight);
+            });
+
+            const texture = new THREE.CanvasTexture(canvas);
+            texture.needsUpdate = true;
+
+            const material = new THREE.SpriteMaterial({
+                map: texture,
+                transparent: true,
+                depthTest: false,
+                depthWrite: false
+            });
+            const sprite = new THREE.Sprite(material);
+            sprite.scale.set(180, 80, 1);
+            sprite.renderOrder = 1;
+            return sprite;
+        }
+
+        function samplePointInsideDimension(dimension, target = new THREE.Vector3(), marginRatio = 0.2) {
+            tempMin.copy(dimension.boundsMin);
+            tempMax.copy(dimension.boundsMax);
+            tempVector.copy(dimension.size).multiplyScalar(marginRatio);
+            tempMin.add(tempVector);
+            tempMax.sub(tempVector);
+
+            target.set(
+                THREE.MathUtils.lerp(tempMin.x, tempMax.x, Math.random()),
+                THREE.MathUtils.lerp(tempMin.y, tempMax.y, Math.random()),
+                THREE.MathUtils.lerp(tempMin.z, tempMax.z, Math.random())
+            );
+            return target;
+        }
+
+        function constrainPositionToDimensions(userData) {
+            if (!userData.dimensionIndices || userData.dimensionIndices.length === 0) {
+                return;
+            }
+
+            const indices = userData.dimensionIndices;
+            tempMin.copy(dimensions[indices[0]].boundsMin);
+            tempMax.copy(dimensions[indices[0]].boundsMax);
+            tempVector.set(0, 0, 0);
+
+            for (let i = 0; i < indices.length; i++) {
+                const dimension = dimensions[indices[i]];
+                if (!dimension) continue;
+                if (i > 0) {
+                    tempMin.min(dimension.boundsMin);
+                    tempMax.max(dimension.boundsMax);
+                }
+                tempVector.add(dimension.center);
+            }
+
+            userData.originalPosition.x = THREE.MathUtils.clamp(userData.originalPosition.x, tempMin.x, tempMax.x);
+            userData.originalPosition.y = THREE.MathUtils.clamp(userData.originalPosition.y, tempMin.y, tempMax.y);
+            userData.originalPosition.z = THREE.MathUtils.clamp(userData.originalPosition.z, tempMin.z, tempMax.z);
+
+            const attractionTarget = tempVector.divideScalar(indices.length);
+            const attractionStrength = indices.length > 1 ? 0.035 : 0.02;
+            userData.originalPosition.lerp(attractionTarget, attractionStrength);
+        }
+
         function createBubblesAndConnections() {
             localDensityState.grid.clear();
-            const bubbleCount = 600; // Увеличено в 20 раз
-            const spreadRadius = 250; // Увеличен радиус распределения
+            const bubbleCount = 600;
+
+            if (bubbles.length > 0) {
+                bubbles.forEach(bubble => {
+                    if (bubble.userData && bubble.userData.forceGlow) {
+                        scene.remove(bubble.userData.forceGlow);
+                    }
+                    scene.remove(bubble);
+                });
+            }
+
+            bubbles = [];
+            connections = [];
+            connectionLines = [];
 
             if (!bubbleGlowTexture) {
                 const glowSize = 256;
@@ -277,21 +535,64 @@
                 bubbleGlowTexture.needsUpdate = true;
             }
 
-            // Создаем пузыри с кластерным распределением
-            for (let i = 0; i < bubbleCount; i++) {
-                const baseRadius = Math.random() * 0.8 + 0.5; // Немного меньше размер для большего количества
-                const geometry = new THREE.SphereGeometry(baseRadius, 16, 8); // Меньше полигонов для производительности
+            dimensions.forEach(dimension => {
+                dimension.bubbleIndices.length = 0;
+            });
 
-                // Цвета пузырей
-                const hue = (i / bubbleCount) * 0.8 + Math.random() * 0.2;
-                const baseBrightness = 0.2;
+            const dimensionAssignment = [];
+            if (dimensions.length > 0) {
+                const basePerDimension = Math.floor(bubbleCount / dimensions.length);
+                for (let d = 0; d < dimensions.length; d++) {
+                    for (let n = 0; n < basePerDimension; n++) {
+                        dimensionAssignment.push(d);
+                    }
+                }
+                while (dimensionAssignment.length < bubbleCount) {
+                    dimensionAssignment.push(Math.floor(Math.random() * dimensions.length));
+                }
+                for (let i = dimensionAssignment.length - 1; i > 0; i--) {
+                    const j = Math.floor(Math.random() * (i + 1));
+                    const temp = dimensionAssignment[i];
+                    dimensionAssignment[i] = dimensionAssignment[j];
+                    dimensionAssignment[j] = temp;
+                }
+            }
+
+            for (let i = 0; i < bubbleCount; i++) {
+                const baseRadius = Math.random() * 0.8 + 0.5;
+                const geometry = new THREE.SphereGeometry(baseRadius, 16, 8);
+
+                const primaryIndex = dimensionAssignment.length > 0 ? dimensionAssignment[i % dimensionAssignment.length] : 0;
+                const primaryDimension = dimensions[primaryIndex];
+
+                let hue;
+                let saturation;
+                let lightness;
+                let baseBrightness = 0.22;
+                if (primaryDimension) {
+                    primaryDimension.color.getHSL(tempHSL);
+                    hue = THREE.MathUtils.euclideanModulo(tempHSL.h + (Math.random() - 0.5) * 0.12, 1);
+                    saturation = THREE.MathUtils.clamp(tempHSL.s + (Math.random() - 0.5) * 0.25, 0.25, 1);
+                    lightness = THREE.MathUtils.clamp(tempHSL.l + (Math.random() - 0.5) * 0.3, 0.25, 0.75);
+                    baseBrightness = 0.22 + (lightness - tempHSL.l) * 0.3;
+                } else {
+                    hue = Math.random();
+                    saturation = 0.65;
+                    lightness = 0.5;
+                }
+
+                const bubbleColor = new THREE.Color().setHSL(hue, saturation, lightness);
+                const emissiveColor = new THREE.Color().setHSL(hue, Math.min(1, saturation * 0.85), Math.min(1, lightness + 0.15));
+                const glowColor = new THREE.Color().setHSL(hue, Math.min(1, saturation * 0.9), Math.min(1, lightness + 0.2));
+                const forceGlowColor = new THREE.Color().setHSL(hue, Math.min(1, saturation * 0.95), Math.min(1, lightness + 0.35));
+
                 const material = new THREE.MeshPhysicalMaterial({
-                    color: new THREE.Color().setHSL(hue, 0.7, 0.5),
+                    color: bubbleColor,
                     metalness: 0.1,
                     roughness: 0.2,
                     transparent: true,
                     opacity: 0.7,
-                    emissive: new THREE.Color().setHSL(hue, 0.7, 0.2),
+                    emissive: emissiveColor,
                     emissiveIntensity: baseBrightness,
                     side: THREE.DoubleSide
                 });
@@ -300,7 +601,7 @@
 
                 const glowMaterial = new THREE.SpriteMaterial({
                     map: bubbleGlowTexture,
-                    color: new THREE.Color().setHSL(hue, 0.7, 0.6),
+                    color: glowColor,
                     transparent: true,
                     opacity: 0.35,
                     blending: THREE.AdditiveBlending,
@@ -313,30 +614,80 @@
                 glowSprite.scale.set(baseGlowScale, baseGlowScale, 1);
                 bubble.add(glowSprite);
 
-                const sizeCoefficient = 0.3 + Math.random() * 1.4;
-                const brightnessCoefficient = 0.3 + Math.random() * 1.4;
+                const forceGlowMaterial = new THREE.SpriteMaterial({
+                    map: bubbleGlowTexture,
+                    color: forceGlowColor,
+                    transparent: true,
+                    opacity: 0,
+                    blending: THREE.AdditiveBlending,
+                    depthWrite: false,
+                    depthTest: false
+                });
+                const forceGlowSprite = new THREE.Sprite(forceGlowMaterial);
+                const forceGlowBaseScale = baseGlowScale * 0.55;
+                forceGlowSprite.scale.set(forceGlowBaseScale, forceGlowBaseScale, 1);
+                forceGlowSprite.visible = false;
+                scene.add(forceGlowSprite);
+
+                const sizeCoefficient = 0.45 + Math.random() * 1.2;
+                const brightnessCoefficient = 0.6 + Math.random() * 0.9;
                 const baseGlowOpacity = glowMaterial.opacity;
 
                 bubble.scale.setScalar(sizeCoefficient);
-                bubble.material.emissiveIntensity = baseBrightness * brightnessCoefficient;
+                bubble.material.emissiveIntensity = THREE.MathUtils.clamp(baseBrightness * brightnessCoefficient, 0.05, 3);
                 glowMaterial.opacity = THREE.MathUtils.clamp(baseGlowOpacity * brightnessCoefficient, 0, 1);
 
-                // Создаем кластерное распределение для более реалистичного графа
-                const clusterIndex = Math.floor(Math.random() * 8); // 8 кластеров
-                const clusterAngle = (clusterIndex / 8) * Math.PI * 2;
-                const clusterRadius = spreadRadius * (0.3 + Math.random() * 0.7);
-                const localSpread = 60; // Разброс внутри кластера
-                
-                bubble.position.set(
-                    Math.cos(clusterAngle) * clusterRadius + (Math.random() - 0.5) * localSpread,
-                    (Math.random() - 0.5) * 150,
-                    Math.sin(clusterAngle) * clusterRadius + (Math.random() - 0.5) * localSpread
-                );
-                
+                const assignedDimensions = [];
+                const basePosition = new THREE.Vector3();
+
+                if (primaryDimension) {
+                    assignedDimensions.push(primaryIndex);
+
+                    if (primaryDimension.clusterCenters.length > 0) {
+                        const clusterCenter = primaryDimension.clusterCenters[Math.floor(Math.random() * primaryDimension.clusterCenters.length)];
+                        basePosition.copy(clusterCenter);
+                    } else {
+                        samplePointInsideDimension(primaryDimension, basePosition, 0.25);
+                    }
+
+                    basePosition.x += (Math.random() - 0.5) * primaryDimension.size.x * 0.25;
+                    basePosition.y += (Math.random() - 0.5) * primaryDimension.size.y * 0.2;
+                    basePosition.z += (Math.random() - 0.5) * primaryDimension.size.z * 0.25;
+
+                    if (dimensions.length > 1 && Math.random() < 0.18) {
+                        let secondaryIndex = Math.floor(Math.random() * dimensions.length);
+                        if (secondaryIndex === primaryIndex) {
+                            secondaryIndex = (secondaryIndex + 1) % dimensions.length;
+                        }
+                        const secondaryDimension = dimensions[secondaryIndex];
+                        if (secondaryDimension) {
+                            assignedDimensions.push(secondaryIndex);
+                            tempVector.copy(primaryDimension.center);
+                            tempVector2.copy(secondaryDimension.center);
+                            const blendFactor = Math.random() * 0.6 + 0.2;
+                            basePosition.lerpVectors(tempVector, tempVector2, blendFactor);
+
+                            const rangeX = Math.min(primaryDimension.size.x, secondaryDimension.size.x) * 0.25;
+                            const rangeY = Math.min(primaryDimension.size.y, secondaryDimension.size.y) * 0.3;
+                            const rangeZ = Math.min(primaryDimension.size.z, secondaryDimension.size.z) * 0.25;
+                            basePosition.x += (Math.random() - 0.5) * rangeX;
+                            basePosition.y += (Math.random() - 0.5) * rangeY;
+                            basePosition.z += (Math.random() - 0.5) * rangeZ;
+                        }
+                    }
+                } else {
+                    basePosition.set(
+                        (Math.random() - 0.5) * 400,
+                        (Math.random() - 0.5) * 200,
+                        (Math.random() - 0.5) * 400
+                    );
+                }
+
+                bubble.position.copy(basePosition);
+
                 bubble.castShadow = true;
                 bubble.receiveShadow = true;
 
-                // Сохраняем параметры для анимации
                 bubble.userData = {
                     id: i,
                     floatSpeed: Math.random() * 0.002 + 0.001,
@@ -355,37 +706,68 @@
                     densityAccumulator: new THREE.Vector3(),
                     pendingForce: new THREE.Vector3(),
                     neighborIndices: [],
-                    localDensity: 0
+                    localDensity: 0,
+                    forceGlow: forceGlowSprite,
+                    forceGlowBaseScale,
+                    forceGlowOffset: new THREE.Vector3(),
+                    forceGlowIntensity: 0,
+                    forceGlowBaseOpacity: 0,
+                    forceGlowTargetScale: forceGlowBaseScale,
+                    dimensionIndices: assignedDimensions
                 };
+
+                constrainPositionToDimensions(bubble.userData);
+                bubble.position.copy(bubble.userData.originalPosition);
+
+                forceGlowSprite.position.copy(bubble.position);
 
                 scene.add(bubble);
                 bubbles.push(bubble);
+
+                const bubbleIndex = bubbles.length - 1;
+                assignedDimensions.forEach(dimensionIndex => {
+                    const dimension = dimensions[dimensionIndex];
+                    if (dimension) {
+                        dimension.bubbleIndices.push(bubbleIndex);
+                    }
+                });
             }
             
-            // Создаем связи на основе расстояния
-            const maxConnectionDistance = 50; // Максимальное расстояние для связи
+            // Создаем связи на основе расстояния и принадлежности к измерениям
+            const maxIntraDimensionDistance = 55;
+            const maxCrossDimensionDistance = 80;
             const minConnectionDistance = 5; // Минимальное расстояние
-            
+
             for (let i = 0; i < bubbles.length; i++) {
                 for (let j = i + 1; j < bubbles.length; j++) {
                     const distance = bubbles[i].position.distanceTo(bubbles[j].position);
-                    
-                    // Вероятность связи обратно пропорциональна расстоянию
-                    if (distance < maxConnectionDistance && distance > minConnectionDistance) {
-                        // Плавающая вероятность от 0.9 (близко) до 0.05 (далеко)
-                        const probability = Math.pow(1 - (distance / maxConnectionDistance), 2);
-                        
-                        if (Math.random() < probability) {
-                            // Сила связи обратно пропорциональна расстоянию
-                            const strength = 1 - (distance / maxConnectionDistance);
-                            
+
+                    const dimsA = bubbles[i].userData.dimensionIndices || [];
+                    const dimsB = bubbles[j].userData.dimensionIndices || [];
+                    let sharedDimension = false;
+                    for (let d = 0; d < dimsA.length && !sharedDimension; d++) {
+                        if (dimsB.includes(dimsA[d])) {
+                            sharedDimension = true;
+                        }
+                    }
+
+                    const effectiveMaxDistance = sharedDimension ? maxIntraDimensionDistance : maxCrossDimensionDistance;
+
+                    if (distance < effectiveMaxDistance && distance > minConnectionDistance) {
+                        const normalizedDistance = 1 - (distance / effectiveMaxDistance);
+                        const probabilityStrength = sharedDimension ? normalizedDistance ** 2 : normalizedDistance ** 1.5 * 0.35;
+
+                        if (Math.random() < probabilityStrength) {
+                            const strength = normalizedDistance * (sharedDimension ? 1 : 0.75);
+
                             connections.push({
                                 from: i,
                                 to: j,
                                 distance: distance,
-                                strength: strength
+                                strength: strength,
+                                sharedDimension
                             });
-                            
+
                             bubbles[i].userData.connections.push(j);
                             bubbles[j].userData.connections.push(i);
                         }
@@ -406,11 +788,19 @@
                 const geometry = new THREE.BufferGeometry().setFromPoints(points);
                 
                 // Материал с толщиной и свечением на основе силы связи
+                const baseHue = connection.sharedDimension
+                    ? 0.5 - connection.strength * 0.25
+                    : 0.08 + (1 - connection.strength) * 0.05;
+                const baseSaturation = connection.sharedDimension ? 0.8 : 0.95;
+                const baseLightness = connection.sharedDimension
+                    ? 0.5 + connection.strength * 0.25
+                    : 0.6 + connection.strength * 0.2;
+
                 const material = new THREE.LineBasicMaterial({
-                    color: new THREE.Color().setHSL(0.5 - connection.strength * 0.3, 0.8, 0.5 + connection.strength * 0.3),
-                    opacity: connection.strength * 0.6 + 0.1,
+                    color: new THREE.Color().setHSL(baseHue, baseSaturation, Math.min(1, baseLightness)),
+                    opacity: connection.strength * (connection.sharedDimension ? 0.6 : 0.45) + 0.1,
                     transparent: true,
-                    linewidth: connection.strength * 3 + 1, // Толщина зависит от силы
+                    linewidth: connection.strength * (connection.sharedDimension ? 3 : 2.2) + 1,
                     blending: THREE.AdditiveBlending
                 });
                 
@@ -419,8 +809,12 @@
                 // Для очень сильных связей добавляем свечение
                 if (connection.strength > 0.7) {
                     const glowMaterial = new THREE.LineBasicMaterial({
-                        color: new THREE.Color().setHSL(0.5 - connection.strength * 0.3, 1, 0.7),
-                        opacity: connection.strength * 0.2,
+                        color: new THREE.Color().setHSL(
+                            connection.sharedDimension ? 0.5 - connection.strength * 0.2 : 0.04,
+                            1,
+                            0.7 + (connection.sharedDimension ? 0 : 0.1)
+                        ),
+                        opacity: connection.strength * (connection.sharedDimension ? 0.2 : 0.15),
                         transparent: true,
                         linewidth: connection.strength * 6 + 2,
                         blending: THREE.AdditiveBlending
@@ -431,7 +825,8 @@
                         from: connection.from,
                         to: connection.to,
                         strength: connection.strength,
-                        isGlow: true
+                        isGlow: true,
+                        sharedDimension: connection.sharedDimension
                     };
                     
                     linesGroup.add(glowLine);
@@ -443,7 +838,8 @@
                     from: connection.from,
                     to: connection.to,
                     strength: connection.strength,
-                    distance: connection.distance
+                    distance: connection.distance,
+                    sharedDimension: connection.sharedDimension
                 };
                 
                 linesGroup.add(line);
@@ -495,6 +891,23 @@
             });
             const avgConnections = (totalConnections / bubbles.length).toFixed(1);
             document.getElementById('avgConnections').textContent = `Среднее связей: ${avgConnections}`;
+
+            if (dimensionStatsElement) {
+                if (!dimensions.length) {
+                    dimensionStatsElement.textContent = '';
+                } else {
+                    const lines = dimensions.map(dimension => {
+                        const colorStyle = dimension.color.getStyle();
+                        return `<span style="color: ${colorStyle};">${dimension.name}: ${dimension.bubbleIndices.length}</span>`;
+                    });
+                    const bridgingCount = bubbles.reduce((total, bubble) => {
+                        const dims = bubble.userData.dimensionIndices || [];
+                        return total + (dims.length > 1 ? 1 : 0);
+                    }, 0);
+                    lines.push(`<span style="color: rgba(255, 255, 255, 0.75);">Пересечения: ${bridgingCount}</span>`);
+                    dimensionStatsElement.innerHTML = lines.join('<br>');
+                }
+            }
         }
         
         function onMouseDown(event) {
@@ -653,6 +1066,27 @@
 
             const time = Date.now() * 0.001;
 
+            for (let d = 0; d < dimensions.length; d++) {
+                const dimension = dimensions[d];
+                const pulse = 0.85 + Math.sin(time * 1.05 + dimension.pulseOffset) * 0.15;
+
+                if (dimension.outline && dimension.outline.material) {
+                    dimension.outline.material.opacity = THREE.MathUtils.lerp(0.22, 0.55, pulse);
+                }
+                if (dimension.fill && dimension.fill.material) {
+                    dimension.fill.material.opacity = THREE.MathUtils.lerp(0.03, 0.08, pulse);
+                }
+                if (dimension.floor && dimension.floor.material) {
+                    dimension.floor.material.opacity = THREE.MathUtils.lerp(0.04, 0.12, pulse);
+                }
+                if (dimension.label && dimension.label.material) {
+                    dimension.label.material.opacity = THREE.MathUtils.clamp(0.65 + (pulse - 0.85) * 1.1, 0.45, 1);
+                    const baseScale = dimension.labelBaseScale || { x: dimension.label.scale.x, y: dimension.label.scale.y };
+                    const scalePulse = 0.96 + Math.sin(time * 2.1 + dimension.pulseOffset) * 0.05;
+                    dimension.label.scale.set(baseScale.x * scalePulse, baseScale.y * scalePulse, 1);
+                }
+            }
+
             rebuildSpatialGrid();
 
             for (let i = 0; i < bubbles.length; i++) {
@@ -688,6 +1122,49 @@
                         pendingForce.copy(accumulator.multiplyScalar(strength));
                     }
                 }
+
+                const forceGlow = userData.forceGlow;
+                if (forceGlow) {
+                    const forceMagnitude = pendingForce.length();
+                    const normalizedStrength = Math.min(
+                        forceMagnitude / localDensityConfig.forceStrength,
+                        1
+                    );
+
+                    userData.forceGlowIntensity = normalizedStrength;
+                    userData.forceGlowBaseOpacity = normalizedStrength * 0.75;
+
+                    const offset = userData.forceGlowOffset;
+                    if (forceMagnitude > 0.0001) {
+                        offset.copy(pendingForce).normalize();
+                        const offsetDistance = THREE.MathUtils.lerp(
+                            userData.baseRadius * userData.sizeCoefficient * 2,
+                            localDensityConfig.neighborRadius * 0.4,
+                            normalizedStrength
+                        );
+                        offset.multiplyScalar(offsetDistance);
+                    } else {
+                        offset.set(0, 0, 0);
+                    }
+
+                    const baseScale = userData.forceGlowBaseScale;
+                    userData.forceGlowTargetScale = baseScale * (0.6 + normalizedStrength * 0.8);
+
+                    forceGlow.visible = normalizedStrength > 0.02;
+                    if (!forceGlow.visible) {
+                        forceGlow.material.opacity = 0;
+                    } else {
+                        forceGlow.material.opacity = THREE.MathUtils.clamp(
+                            userData.forceGlowBaseOpacity,
+                            0,
+                            1
+                        );
+                    }
+
+                    forceGlow.position.copy(basePosition).add(offset);
+                    const appliedScale = userData.forceGlowTargetScale;
+                    forceGlow.scale.set(appliedScale, appliedScale, 1);
+                }
             }
 
             for (let i = 0; i < bubbles.length; i++) {
@@ -702,6 +1179,7 @@
                 }
 
                 userData.originalPosition.add(userData.driftVelocity);
+                constrainPositionToDimensions(userData);
 
                 const basePosition = userData.originalPosition;
 
@@ -740,6 +1218,27 @@
                         1
                     );
                 }
+
+                if (userData.forceGlow) {
+                    const forceGlow = userData.forceGlow;
+                    const intensity = userData.forceGlowIntensity || 0;
+                    const baseOpacity = userData.forceGlowBaseOpacity || 0;
+                    const isVisible = intensity > 0.02;
+                    forceGlow.visible = isVisible;
+
+                    if (isVisible) {
+                        const pulse = 0.85 + Math.sin(time * 3.5 + userData.phase) * 0.15 * (0.5 + intensity * 0.5);
+                        forceGlow.material.opacity = THREE.MathUtils.clamp(baseOpacity * pulse, 0, 1);
+
+                        const pulseScale = 0.9 + Math.sin(time * 4.1 + userData.phase * 1.3) * 0.1 * intensity;
+                        const targetScale = userData.forceGlowTargetScale * pulseScale;
+                        forceGlow.scale.set(targetScale, targetScale, 1);
+
+                        forceGlow.position.copy(basePosition).add(userData.forceGlowOffset);
+                    } else {
+                        forceGlow.material.opacity = 0;
+                    }
+                }
             }
 
             // Обновление линий связей
@@ -759,10 +1258,18 @@
                 
                 line.geometry.attributes.position.needsUpdate = true;
                 
-                // Пульсация яркости для сильных связей
-                if (userData.strength > 0.5 && !userData.isGlow) {
-                    const pulsation = 0.8 + Math.sin(time * 2 + userData.from) * 0.2;
-                    line.material.opacity = userData.strength * 0.6 * pulsation;
+                if (!userData.isGlow) {
+                    if (userData.sharedDimension) {
+                        if (userData.strength > 0.45) {
+                            const pulsation = 0.82 + Math.sin(time * 2 + userData.from) * 0.18;
+                            const targetOpacity = userData.strength * 0.6 * pulsation;
+                            line.material.opacity = THREE.MathUtils.lerp(line.material.opacity, targetOpacity, 0.2);
+                        }
+                    } else {
+                        const bridgePulse = 0.7 + Math.sin(time * 1.4 + userData.to) * 0.3;
+                        const targetOpacity = (0.25 + userData.strength * 0.35) * bridgePulse;
+                        line.material.opacity = THREE.MathUtils.lerp(line.material.opacity, targetOpacity, 0.25);
+                    }
                 }
             });
             


### PR DESCRIPTION
## Summary
- add a dedicated sprite-based glow for each bubble to visualize force direction and strength
- update the physics loop to position, scale, and fade the force glow according to pending force vectors
- synchronize the glow during rendering with subtle pulsing to match existing bubble effects
- introduce named rectangular dimension volumes with animated overlays and labels to represent multidimensional space
- spawn bubble clusters inside dimensions, allow cross-dimensional bridging, and update stats/connection visuals accordingly
- render dimension volume fills double-sided so the translucent walls remain visible while navigating inside the space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d14ba16c00832693aae40ec0751c31